### PR TITLE
update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a problem you're experiencing
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please search the existing issues (both open and closed).
+
+        ---
+
+        Thank you for taking the time to file a bug report. To address this bug as fast as possible, we need some information.
+  - type: input
+    id: blog-version
+    attributes:
+      label: Filament Blog Version
+      description: Please provide the full version of the Filament-Blog you have installed.
+      placeholder: v0.1.6
+    validations:
+      required: true
+  - type: input
+    id: filament-version
+    attributes:
+      label: Filament Version
+      description: Please provide the full version of the Filament you have installed.
+      placeholder: v2.0.0
+    validations:
+      required: true
+  - type: input
+    id: laravel-version
+    attributes:
+      label: Laravel Version
+      description: Please provide the full Laravel version of your project.
+      placeholder: v8.0.0
+    validations:
+      required: true
+  - type: input
+    id: livewire-version
+    attributes:
+      label: Livewire Version
+      description: Please provide the full Livewire version of your project, if applicable.
+      placeholder: v2.0.0
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP Version
+      description: Please provide the full PHP version of your server.
+      placeholder: PHP 8.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: What happened when you experienced the problem?
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Which steps do we need to take to reproduce the problem? Any code examples need to be **as short as possible**, remove any code that is unrelated to the bug.  **This issue will be automatically closed and not reviewed if detailed replication steps are missing.**
+    validations:
+      required: true
+  - type: input
+    id: reproduction
+    attributes:
+      label: Reproduction repository
+      description: The URL of a public Git repository which contains the minimal amount of code to reproduce the problem. This allows us to fix the problem much quicker. **This issue will be automatically closed and not reviewed if this is missing. Please make sure to format the URL starting with `https://github.com`.**
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: If applicable, provide relevant log output. No need for backticks here.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Ask a question
-    url: https://github.com/stephenjude/filament-blog/discussions/new?category=q-a
-    about: Ask the community for help
-  - name: Request a feature
-    url: https://github.com/stephenjude/filament-blog/discussions/new?category=ideas
-    about: Share ideas for new features
   - name: Report a security issue
     url: https://github.com/stephenjude/filament-blog/security/policy
     about: Learn how to notify us for sensitive bugs
-  - name: Report a bug
-    url: https://github.com/stephenjude/filament-blog/issues/new
-    about: Report a reproducable bug

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,11 @@
+name: Request a feature
+description: Share ideas for new features
+labels: Ideas
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature description
+      description: Please describe your feature Idea here
+    validations:
+      required: true


### PR DESCRIPTION
right now in the issue section when you click any template it will return 404 because the links redirect users to the discussion section which is disabled in this repo so I updated the issue templates.
i used filament/filament issue templates for bug report with some adjusment