### PR TITLE
Allow nullable asset fields

### DIFF
--- a/src/Models/Author.php
+++ b/src/Models/Author.php
@@ -38,7 +38,7 @@ class Author extends Model
 
     public function photoUrl(): Attribute
     {
-        return Attribute::get(fn () => asset(Storage::url($this->photo)));
+        return Attribute::get(fn () => $this->photo ? asset(Storage::url($this->photo)) : '');
     }
 
     public function posts(): HasMany

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -48,7 +48,7 @@ class Post extends Model
 
     public function bannerUrl(): Attribute
     {
-        return Attribute::get(fn () => asset(Storage::url($this->banner)));
+        return Attribute::get(fn () => $this->banner ? asset(Storage::url($this->banner)) : '');
     }
 
     public function scopePublished(Builder $query)


### PR DESCRIPTION
When using the s3 driver, Flysystem fails with a type error for the nullable avatar and banner image fields. This PR checks that the fields are not null before requesting the assets from storage.