### PR TITLE
Reoder down method. Fixes rollback issue

### DIFF
--- a/database/migrations/create_filament_blog_tables.php.stub
+++ b/database/migrations/create_filament_blog_tables.php.stub
@@ -53,8 +53,8 @@ return new class () extends Migration {
      */
     public function down()
     {
+        Schema::dropIfExists('blog_posts');
         Schema::dropIfExists('blog_categories');
         Schema::dropIfExists('blog_authors');
-        Schema::dropIfExists('blog_posts');
     }
 };


### PR DESCRIPTION
Fixes the below error:

Rollback option is not working due to this error: 

  SQLSTATE[2BP01]: Dependent objects still exist: 7 ERROR:  cannot drop table blog_categories because other objects depend on it
DETAIL:  constraint blog_posts_blog_category_id_foreign on table blog_posts depends on table blog_categories
HINT:  Use DROP ... CASCADE to drop the dependent objects too. (Connection: pgsql, SQL: drop table if exists "blog_categories")