### PR TITLE
Make the content field required and wrap long content

### DIFF
--- a/src/Resources/AuthorResource.php
+++ b/src/Resources/AuthorResource.php
@@ -88,6 +88,7 @@ class AuthorResource extends Resource
                 Tables\Columns\TextColumn::make('name')
                     ->label(__('filament-blog::filament-blog.name'))
                     ->searchable()
+					->wrap()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('email')
                     ->label(__('filament-blog::filament-blog.email'))

--- a/src/Resources/CategoryResource.php
+++ b/src/Resources/CategoryResource.php
@@ -81,9 +81,11 @@ class CategoryResource extends Resource
                 Tables\Columns\TextColumn::make('name')
                     ->label(__('filament-blog::filament-blog.name'))
                     ->searchable()
+					->wrap()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('slug')
                     ->label(__('filament-blog::filament-blog.slug'))
+					->wrap()
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\IconColumn::make('is_visible')

--- a/src/Resources/PostResource.php
+++ b/src/Resources/PostResource.php
@@ -136,6 +136,7 @@ class PostResource extends Resource
                 Tables\Columns\TextColumn::make('title')
                     ->label(__('filament-blog::filament-blog.title'))
                     ->searchable()
+					->wrap()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('author.name')
                     ->label(__('filament-blog::filament-blog.author_name'))

--- a/src/Traits/HasContentEditor.php
+++ b/src/Traits/HasContentEditor.php
@@ -10,6 +10,7 @@ trait HasContentEditor
 
         return $defaultEditor::make($field)
             ->label(__('filament-blog::filament-blog.content'))
+			->required()
             ->toolbarButtons(config('filament-blog.toolbar_buttons'))
             ->columnSpan([
                 'sm' => 2,


### PR DESCRIPTION
The content field is currently not ->required() although the database field is not ->nullable().
This PR makes the content field required.

In addition this PR wraps long content within the table.