### PR TITLE
Display Visibility for Private S3 Storage Images

### DIFF
--- a/config/filament-blog.php
+++ b/config/filament-blog.php
@@ -19,6 +19,7 @@ return [
         'directory' => 'blog',
         'maxSize' => 5120,
         'cropAspectRatio' => '16:9',
+        'visibility' => 'public',
     ],
 
     /**
@@ -39,6 +40,7 @@ return [
         'disk' => 'public',
         'directory' => 'blog',
         'maxSize' => 5120,
+        'visibility' => 'public',
     ],
 
     /**

--- a/src/Resources/AuthorResource.php
+++ b/src/Resources/AuthorResource.php
@@ -45,6 +45,7 @@ class AuthorResource extends Resource
                             ->label(__('filament-blog::filament-blog.photo'))
                             ->image()
                             ->disk(config('filament-blog.avatar.disk', 'public'))
+                            ->visibility(config('filament-blog.avatar.visibility', 'public'))
                             ->maxSize(config('filament-blog.avatar.maxSize', 5120))
                             ->directory(config('filament-blog.avatar.directory', 'blog'))
                             ->columnSpan([
@@ -83,6 +84,8 @@ class AuthorResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\ImageColumn::make('photo')
+                    ->disk(config('filament-blog.avatar.disk', 'public'))
+                    ->visibility(config('filament-blog.banner.visibility', 'public'))
                     ->label(__('filament-blog::filament-blog.photo'))
                     ->circular(),
                 Tables\Columns\TextColumn::make('name')

--- a/src/Resources/PostResource.php
+++ b/src/Resources/PostResource.php
@@ -73,6 +73,7 @@ class PostResource extends Resource
                             ->maxSize(config('filament-blog.banner.maxSize', 5120))
                             ->imageCropAspectRatio(config('filament-blog.banner.cropAspectRatio', '16:9'))
                             ->disk(config('filament-blog.banner.disk', 'public'))
+                            ->visibility(config('filament-blog.banner.visibility', 'public'))
                             ->directory(config('filament-blog.banner.directory', 'blog'))
                             ->columnSpan([
                                 'sm' => 2,

--- a/src/Resources/PostResource.php
+++ b/src/Resources/PostResource.php
@@ -132,6 +132,8 @@ class PostResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\ImageColumn::make('banner')
+                    ->disk(config('filament-blog.banner.disk', 'public'))
+                    ->visibility(config('filament-blog.banner.visibility', 'public'))
                     ->label(__('filament-blog::filament-blog.banner'))
                     ->circular(),
                 Tables\Columns\TextColumn::make('title')


### PR DESCRIPTION
This PR improves image visibility in the banner and avatar sections when the default storage disk is S3 and set to private. Previously, images did not appear in the table or other sections due to access restrictions.