### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ php artisan migrate
 You'll have to register the plugin in your panel provider.
 
 ```php
+use Stephenjude\FilamentBlog\BlogPlugin;
+
 public function panel(Panel $panel): Panel
 {
     return $panel
         ...
         ->plugin(
-            Stephenjude\FilamentBlog\BlogPlugin::make()
+            BlogPlugin::make()
         );
 }
 ```


### PR DESCRIPTION
fix:  Class "App\Providers\Filament\Stephenjude\FilamentBlog\BlogPlugin" not found

I think is a bit cleaner this way, the same fix could probably be just  \Stephenjude\FilamentBlog\BlogPlugin::make().

But now how is in this current docs it is relative to the current namespace (App\Providers\Filament\...) and ends up looking for:
`App\Providers\Filament\Stephenjude\FilamentBlog\BlogPlugin`