### PR TITLE
Add support for Filament 5 and Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,11 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4]
-        laravel: ['12.0']
+        laravel: ['12.0', '13.0']
         stability: [prefer-stable]
+        exclude:
+          - php: 8.3
+            laravel: '13.0'
         include:
           - laravel: '12.0'
             testbench: '^10.0'
+          - laravel: '13.0'
+            testbench: '^11.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
     "require": {
         "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16.1",
-        "filament/filament": "^4.0",
-        "filament/spatie-laravel-tags-plugin": "^v3.0"
+        "filament/filament": "^4.0|^5.0",
+        "filament/spatie-laravel-tags-plugin": "^v3.0|^v4.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13.1",
         "nunomaduro/collision": "^7.8.1|^8.0",
-        "orchestra/testbench": "^9.0|^10.0",
-        "pestphp/pest": "^2.18.2|^3.7",
-        "pestphp/pest-plugin-arch": "^2.3.3|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.2|^3.1",
-        "pestphp/pest-plugin-livewire": "^2.1|^3.0"
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.18.2|^3.7|^4.0",
+        "pestphp/pest-plugin-arch": "^2.3.3|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.2|^3.1|^4.0",
+        "pestphp/pest-plugin-livewire": "^2.1|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Expand `filament/filament` constraint to `^4.0|^5.0` and `filament/spatie-laravel-tags-plugin` to `^v3.0|^v4.0`.
- Allow `orchestra/testbench: ^11.0` and Pest 4 across all pest plugins for Laravel 13 support.
- Extend the CI matrix to test Laravel 13 with testbench `^11.0`. PHP 8.3 is excluded from the Laravel 13 jobs since pest-plugin-laravel v4 (the only release supporting Laravel 13) requires PHP 8.4+.